### PR TITLE
Update shell_helpers.rb add require for OpenStruct

### DIFF
--- a/lib/piotrb_cli_utils/shell_helpers.rb
+++ b/lib/piotrb_cli_utils/shell_helpers.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+require "ostruct"
 
 module PiotrbCliUtils
   module ShellHelpers


### PR DESCRIPTION
I was running into the following using `tf_current` from `mux_tf`

```
 Validating module ...
/Users/rebeccagrey/.rbenv/versions/3.3.6/lib/ruby/gems/3.3.0/gems/piotrb_cli_utils-0.1.0/lib/piotrb_cli_utils/shell_helpers.rb:47:in `capture_shell': uninitialized constant PiotrbCliUtils::ShellHelpers::OpenStruct (NameError)
```

under ruby 3.3.6

and adding `require "ostruct"` to the top of this file fixed the problem, whatever it was

